### PR TITLE
Pull Request: Enhancements to node-shutdown-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,41 @@ var shutdownManager = require('node-shutdown-manager').createShutdownManager({
 });
 ```
 
+### Timeout
+
+Set a configuration setting of 'timeout' in milliseconds to limit how long the manager waits for promises to be fulfilled.
+
+```javascript
+var shutdownManager = require('node-shutdown-manager').createShutdownManager({
+	timeout: 10000 // Limit async shutdown promises to 10 seconds to execute
+});
+```
+
+### Events
+
+* Event 'preShutdown' calls a method with the arguments (reason, err).  If no listener is specified, the default action is to log the received event.  Reason will be SIGINT, TERM, exit, or uncaughtException.
+
+* Event 'shutdownActionException' is emitted if an exception is thrown out of a shutdown action.  Function is passed (err, method).  If no listener is specified, the default action is to log the received event.
+
+* Event 'shutdownComplete' is emitted once the shutdown actions are all executed.  Function is passed (exitCode, errors).  If no listener is specified, the default action is to log and call process.exit.  WARNING: If you register a listener to this event, you are responsible for calling Process.exit()  This allows the caller to alter exit codes or other details about the exit.
+
+```javascript
+var shutdownManager = require('node-shutdown-manager').createShutdownManager({});
+shutdownManager.on('preShutdown', function( reason, err) {
+    log.console("Shutting down for: "+reason);
+    log.console("Error: "+err.stack || err);
+});
+shutdownManager.on('shutdownActionException', function(err, method) {
+    log.console("Error in shutdown action being ignored:");
+    log.console("Error: "+err.stack || err);
+});
+shutdownManager.on('shutdownComplete', function(err, method) {
+    log.console("Shutdown actions complete");
+    log.console("Error: "+err.stack || err);
+    process.exit(0); // For example, if you never want to exit with an error code
+});
+```
+
 ## Shutdown Process
 
 The manager detects the following situations:
@@ -61,7 +96,6 @@ The manager detects the following situations:
 * When your application is shutting down due to an uncaught exception.
 
 It is important to know that other situations will cause the manager not to function.  For example, if your application is force closed (by receiving the SIGKILL signal), then the shutdown manager will not be executed.
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Once created, you can add a method to the shutdown action chain by simply callin
 manager.addShutdownAction(sampleFunction);
 ```
 
+Additionally you can use the ```addFinalShutdownAction``` method.  This method is identical to addShutdownAction BUT it these methods are executed only after all the ```addShutdownAction``` promises are fulfilled.  This allows you to delay shutdown of some components (such as loggers) so that they are available until all the components shutdown.
+
 ### Asynchronous Functions
 
 You can add asynchronous functions to the action chain as long as they return a promise (that conforms to [CommonJS Promises/A](http://wiki.commonjs.org/wiki/Promises/A)).  I would recommend using [Q](https://github.com/kriskowal/q) if you are looking for a library that supports the promise spec.

--- a/lib/shutdownManager.js
+++ b/lib/shutdownManager.js
@@ -57,7 +57,7 @@ function ShutdownManager (params) {
 
 	process.on('uncaughtException', function (err) {
 		that._log('Uncaught Exception Received, Beginning Shutdown Process');
-		that._log('Exception: ' + err);
+		that._log('Exception: ' + (err && err.stack) ? err.stack : err);
 		that._shutdown(255, params.timeout);
 	});
 
@@ -101,7 +101,7 @@ ShutdownManager.prototype._shutdown = function(exitCode, timeout) {
                                 promises.push(result);
                         }
                 } catch (err) {
-                        that._log("Ignoring Exception Caught from Callback: "+err);
+                        that._log("Ignoring Exception Caught from Callback: "+ (err && err.stack) ? err.stack : err);
                 }
 	});
 	var rv = q.allResolved(promises);

--- a/lib/shutdownManager.js
+++ b/lib/shutdownManager.js
@@ -34,12 +34,15 @@ var DEFAULT_SHUTDOWN_ON_UNCAUGHT_EXCEPTION = true;
  *		is not passed in, the console will be used.
  *     * +loggingPrefix+ - (<tt>String</tt>) The classes uses a default prefix for all log
  *		messages.  You can pass in your own prefix instead of the default.
+ *     * +timeout+ - (<tt>Integer</tt>) If set, the timeout (in milliseconds)
+ *              for waiting for the action promises to complete.  Default is none (infinite wait)
  */
 function ShutdownManager (params) {
         // Set State
 	var that = this;
 	this.isShuttingDown = false;
 	this.actionChain = [];
+	this.finalActionChain = [];
 
 	// Set Parameters
 	this.logger = (params && params.hasOwnProperty("logger")) ? params.logger : null;
@@ -48,7 +51,7 @@ function ShutdownManager (params) {
 
 	// Add Process Handlers
 	process.on('SIGINT', function() {
-                if (!that.emit('preShutdown', 'SIGINT', err)) {
+                if (!that.emit('preShutdown', 'SIGINT')) {
     		    that._log("Received SIGINT, Beginning Shutdown Process");
                 }
 		that._shutdown(128+2, params.timeout);
@@ -96,16 +99,26 @@ ShutdownManager.prototype.addShutdownAction = function(func) {
 };
 
 /**
+ * Adds a function to be performed when a shutdown is detected.  This
+ * can be either a synchronous function or an asynchronous function
+ * which returns a promise (CommonJS Promises/A).
+ *
+ * Actions registered with addFinalShutdownAction are executed after 
+ * all the actions registered with addShutdownAction are complete.
+ *
+ * @param [Function] The function to be added to the shutdown chain
+ */
+ShutdownManager.prototype.addFinalShutdownAction = function(func) {
+	this.finalActionChain.push(func);
+};
+
+/**
  * @api private
  */
-ShutdownManager.prototype._shutdown = function(exitCode, timeout) {
+ShutdownManager.prototype._executeActions = function(_actionChain) {
 	var that = this;
-	if(this.isShuttingDown) {
-		return;
-	}
-	this.isShuttingDown = true;
 	var promises = [];
-	this.actionChain.forEach(function(chainFunc) {
+	_actionChain.forEach(function(chainFunc) {
             try {
                 var result = chainFunc.apply(this);
                 if(that._isPromise(result)) {
@@ -117,15 +130,40 @@ ShutdownManager.prototype._shutdown = function(exitCode, timeout) {
                 }
             }
 	});
-	var rv = q.allResolved(promises);
-        if (timeout) {
+        return promises;
+}
+
+/**
+ * @api private
+ */
+ShutdownManager.prototype._shutdown = function(exitCode, timeout) {
+    var that = this;
+    if(this.isShuttingDown) {
+        return;
+    }
+    this.isShuttingDown = true;
+
+    var promises = that._executeActions(this.actionChain);
+
+    var rv = q.allResolved(promises);
+    if (timeout > 0) {
+        rv = rv.timeout(timeout);
+    }
+    rv.then(function() {
+        promises = that._executeActions(that.finalActionChain);
+
+        var rv = q.allResolved(promises);
+        if (timeout > 0) {
             rv = rv.timeout(timeout);
         }
-	rv.then(function() {
-		that._exit(exitCode);
-	}, function(error) {
-		that._exit(255, error);
-	});
+        rv.then(function() {
+            that._exit(exitCode);
+        }, function(error) {
+            that._exit(255, error);
+        });
+    }, function(error) {
+        that._exit(255, error);
+    });
 };
 
 /**

--- a/lib/shutdownManager.js
+++ b/lib/shutdownManager.js
@@ -18,6 +18,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 var q = require('q');
+var util = require('util');
+var EventEmitter = require('events').EventEmitter;
 
 // DEFAULTS
 var DEFAULT_LOGGING_PREFIX = "[ShutdownManager]: ";
@@ -34,7 +36,7 @@ var DEFAULT_SHUTDOWN_ON_UNCAUGHT_EXCEPTION = true;
  *		messages.  You can pass in your own prefix instead of the default.
  */
 function ShutdownManager (params) {
-	// Set State
+        // Set State
 	var that = this;
 	this.isShuttingDown = false;
 	this.actionChain = [];
@@ -46,30 +48,39 @@ function ShutdownManager (params) {
 
 	// Add Process Handlers
 	process.on('SIGINT', function() {
-		that._log("Received SIGINT, Beginning Shutdown Process");
+                if (!that.emit('preShutdown', 'SIGINT', err)) {
+    		    that._log("Received SIGINT, Beginning Shutdown Process");
+                }
 		that._shutdown(128+2, params.timeout);
 	});
 
 	process.on('SIGTERM', function() {
-		that._log("Received SIGTERM, Beginning Shutdown Process");
+                if (!that.emit('preShutdown', 'SIGTERM')) {
+		    that._log("Received SIGTERM, Beginning Shutdown Process");
+                }
 		that._shutdown(128+15, params.timeout);
 	});
 
 	process.on('uncaughtException', function (err) {
-		that._log('Uncaught Exception Received, Beginning Shutdown Process');
-		that._log('Exception: ' + (err && err.stack) ? err.stack : err);
-		that._shutdown(255, params.timeout);
+                if (!that.emit('preShutdown', 'uncaughtException', err)) {
+                    that._log('Uncaught Exception Received, Beginning Shutdown Process');
+                    that._log('Exception: '+err);
+                }
+ 	        that._shutdown(255, params.timeout);
 	});
 
 	process.on('exit', function() {
 		// Just in case we are getting to exit without previous conditions being met
 		// Not sure if this happens - will test.
 		if(!that.isShuttingDown) {
-			that._log("Application Exiting for Undefined Reason, Beginning Shutdown Process");
-			that._shutdown(null, params.timeout);
+                    that.emit('preShutdown', 'exit');
+                    that._log("Application Exiting for Undefined Reason, Beginning Shutdown Process");
+                    that._shutdown(null, params.timeout);
 		}
 	});
+        EventEmitter.call(this);
 }
+util.inherits(ShutdownManager, EventEmitter);
 
 module.exports = ShutdownManager;
 
@@ -95,14 +106,16 @@ ShutdownManager.prototype._shutdown = function(exitCode, timeout) {
 	this.isShuttingDown = true;
 	var promises = [];
 	this.actionChain.forEach(function(chainFunc) {
-                try {
-                        var result = chainFunc.apply(this);
-                        if(that._isPromise(result)) {
-                                promises.push(result);
-                        }
-                } catch (err) {
-                        that._log("Ignoring Exception Caught from Callback: "+ (err && err.stack) ? err.stack : err);
+            try {
+                var result = chainFunc.apply(this);
+                if(that._isPromise(result)) {
+                    promises.push(result);
                 }
+            } catch (err) {
+                if (!that.emit('shutdownActionException', err, chainFunc)) {
+                    that._log("Ignoring Exception Caught from Callback: "+err);
+                }
+            }
 	});
 	var rv = q.allResolved(promises);
         if (timeout) {
@@ -119,13 +132,15 @@ ShutdownManager.prototype._shutdown = function(exitCode, timeout) {
  * @api private
  */
 ShutdownManager.prototype._exit = function(exitCode, errors) {
-	if(errors) {
-		this._log("Exiting with Error(s): " + errors);
-		process.exit(exitCode);
-	} else {
-		this._log("Exiting without errors");
-                process.exit(exitCode);
-	}
+    if (!this.emit('shutdownComplete', errors, exitCode)) {
+        if (errors) {
+            this._log("Exiting with Error(s): " + errors);
+            process.exit(exitCode);
+        } else {
+            this._log("Exiting without errors");
+            process.exit(exitCode);
+        }
+    }
 };
 
 /**

--- a/lib/shutdownManager.js
+++ b/lib/shutdownManager.js
@@ -47,18 +47,18 @@ function ShutdownManager (params) {
 	// Add Process Handlers
 	process.on('SIGINT', function() {
 		that._log("Received SIGINT, Beginning Shutdown Process");
-		that._shutdown();
+		that._shutdown(128+2, params.timeout);
 	});
 
 	process.on('SIGTERM', function() {
 		that._log("Received SIGTERM, Beginning Shutdown Process");
-		that._shutdown();
+		that._shutdown(128+15, params.timeout);
 	});
 
 	process.on('uncaughtException', function (err) {
 		that._log('Uncaught Exception Received, Beginning Shutdown Process');
 		that._log('Exception: ' + err);
-		that._shutdown();
+		that._shutdown(255, params.timeout);
 	});
 
 	process.on('exit', function() {
@@ -66,7 +66,7 @@ function ShutdownManager (params) {
 		// Not sure if this happens - will test.
 		if(!that.isShuttingDown) {
 			that._log("Application Exiting for Undefined Reason, Beginning Shutdown Process");
-			that._shutdown();
+			that._shutdown(null, params.timeout);
 		}
 	});
 }
@@ -87,7 +87,7 @@ ShutdownManager.prototype.addShutdownAction = function(func) {
 /**
  * @api private
  */
-ShutdownManager.prototype._shutdown = function() {
+ShutdownManager.prototype._shutdown = function(exitCode, timeout) {
 	var that = this;
 	if(this.isShuttingDown) {
 		return;
@@ -95,29 +95,36 @@ ShutdownManager.prototype._shutdown = function() {
 	this.isShuttingDown = true;
 	var promises = [];
 	this.actionChain.forEach(function(chainFunc) {
-		var result = chainFunc.apply(this);
-		if(that._isPromise(result)) {
-			promises.push(result);
-		}
+                try {
+                        var result = chainFunc.apply(this);
+                        if(that._isPromise(result)) {
+                                promises.push(result);
+                        }
+                } catch (err) {
+                        that._log("Ignoring Exception Caught from Callback: "+err);
+                }
 	});
-	return q.allResolved(promises)
-	.then(function() {
-		that._exit();
+	var rv = q.allResolved(promises);
+        if (timeout) {
+            rv = rv.timeout(timeout);
+        }
+	rv.then(function() {
+		that._exit(exitCode);
 	}, function(error) {
-		that._exit(error);
+		that._exit(255, error);
 	});
 };
 
 /**
  * @api private
  */
-ShutdownManager.prototype._exit = function(errors) {
+ShutdownManager.prototype._exit = function(exitCode, errors) {
 	if(errors) {
 		this._log("Exiting with Error(s): " + errors);
-		process.exit(1);
+		process.exit(exitCode);
 	} else {
 		this._log("Exiting without errors");
-		process.exit();
+                process.exit(exitCode);
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-shutdown-manager",
   "preferGlobal": false,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "David Tucker <david@davidtucker.net>",
   "description": "performs a chain of actions when a shutdown is detected",
   "repository": {


### PR DESCRIPTION
First, thanks for publishing node-shutdown-manager - I was just about to write something nearly identical when I found this.

I made some enhancements to node-shutdown-manager...summary:

1) try/catch when running actions
2) ability to specify 2 tiers of actions so that you can keep some services alive until the first batch is complete (possibly loggers, databases, etc...depending what you are doing) - In theory could be generalized to N layers but I did not carry it to that extreme.
3) Added events so that behavior can be customized in a backwards-compatible manner
4) Added a timeout for the waiting on promises so it does not hang in shutdown
5) Altered exit codes for SIGINT and SIGTERM to be consistent with Node's defaults
6) Updated docs and version #

One thing I did not do - I believe it would make sense for node-shutdown-manager to be a singleton...then libraries could depend on it without spawning secondary copies of the object...something to think about...
- M
