### PR TITLE
Add shutdown handler for unhandled rejected promises

### DIFF
--- a/lib/shutdownManager.js
+++ b/lib/shutdownManager.js
@@ -72,6 +72,14 @@ function ShutdownManager (params) {
  	        that._shutdown(255, params.timeout);
 	});
 
+        process.on('unhandledRejection', function (err) {
+                if (!that.emit('preShutdown', 'unhandledRejection', err)) {
+                    that._log('Unhandled Rejected Promise Received, Beginning Shutdown Process');
+                    that._log('Rejection: '+err);
+                }
+                that._shutdown(255, params.timeout);
+        });
+
 	process.on('exit', function() {
 		// Just in case we are getting to exit without previous conditions being met
 		// Not sure if this happens - will test.


### PR DESCRIPTION
The current code triggers a shutdown when an unhandled exception occurs but not when an unhandled rejected promise occurs.  An unhandled rejected promise should be considered as fatal as an unhandled exception, and it should also trigger a shutdown signal.